### PR TITLE
Replace --socket=x11 permission with fallback-x11

### DIFF
--- a/sh.ppy.osu.yaml
+++ b/sh.ppy.osu.yaml
@@ -7,7 +7,7 @@ build-options:
   no-debuginfo: true
 finish-args:
   - --share=ipc
-  - --socket=x11-fallback
+  - --socket=fallback-x11
   - --socket=wayland
   - --share=network
   - --device=all

--- a/sh.ppy.osu.yaml
+++ b/sh.ppy.osu.yaml
@@ -7,7 +7,7 @@ build-options:
   no-debuginfo: true
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=x11-fallback
   - --socket=wayland
   - --share=network
   - --device=all


### PR DESCRIPTION
The GNOME Software considers applications requiring x11 as unsafe. There's a way to declare it uses Wayland, but can use X11 as a fallback, on desktop environments where Wayland doesn't run.

More info here:
https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/770#note_1136536

Fixes #36 