### PR TITLE
Disable publish delay

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
+	"publish-delay-hours": 0,
 	"only-arches": [
 		"x86_64"
 	]


### PR DESCRIPTION
Flathub has a built-in 3-hour delay for a new build to hit the public repository.
Until then, it is only available in the testing repository.
This PR removes the delay, so once the build completes, it is immediately available to the users.

## Related links

https://github.com/flathub/flathub/wiki/App-Maintenance#automatic-publishing-delay/
https://blogs.gnome.org/alexl/2019/02/19/changes-in-flathub-land/
