### PR TITLE
Fix flathub build failing

### DIFF
--- a/sh.ppy.osu.appdata.xml
+++ b/sh.ppy.osu.appdata.xml
@@ -71,6 +71,7 @@
     <!-- Assets used by osu! is licensed under CC-BY-NC 4.0 (https://creativecommons.org/licenses/by-nc/4.0/legalcode) -->
     <developer_name>ppy Pty Ltd</developer_name>
     <releases>
+        <release version="2022.1205.0" date="2022-12-05"/>
         <release version="2022.1101.0" date="2022-11-01"/>
         <release version="2022.1031.0" date="2022-10-31"/>
         <release version="2022.1022.0" date="2022-10-22"/>

--- a/sh.ppy.osu.appdata.xml
+++ b/sh.ppy.osu.appdata.xml
@@ -72,6 +72,7 @@
     <developer_name>ppy Pty Ltd</developer_name>
     <releases>
         <release version="2022.1205.0" date="2022-12-05"/>
+        <release version="2022.1117.0" date="2022-11-17"/>
         <release version="2022.1101.0" date="2022-11-01"/>
         <release version="2022.1031.0" date="2022-10-31"/>
         <release version="2022.1022.0" date="2022-10-22"/>

--- a/sh.ppy.osu.yaml
+++ b/sh.ppy.osu.yaml
@@ -48,6 +48,8 @@ modules:
       - mv ./squashfs-root/usr/bin/* /app/bin
         # desktop file
       - install -D -m 644 ./squashfs-root/osu!.desktop /app/share/applications/sh.ppy.osu.desktop
+        # The following two lines can be removed after flathub supports version 1.5 of desktop entry files
+        # See https://discourse.flathub.org/t/what-version-of-desktop-entry-file-is-allowed-in-flathub/2351
       - desktop-file-edit --remove-key="SingleMainWindow" --set-key="Version" --set-value="1.4" /app/share/applications/sh.ppy.osu.desktop
       - desktop-file-edit --set-key="X-SingleMainWindow" --set-value="true" /app/share/applications/sh.ppy.osu.desktop
       - desktop-file-edit --set-key="Icon" --set-value="sh.ppy.osu" /app/share/applications/sh.ppy.osu.desktop

--- a/sh.ppy.osu.yaml
+++ b/sh.ppy.osu.yaml
@@ -84,8 +84,8 @@ modules:
       - install -D -m 644 sh.ppy.osu.appdata.xml /app/share/metainfo/sh.ppy.osu.appdata.xml
     sources:
       - type: file
-         url: https://github.com/ppy/osu/releases/download/2022.1205.0/osu.AppImage
-         sha256: deda93a2c945343d82d5f77c729e8206145c2e24f66a33dc3449888655b86e2c
+        url: https://github.com/ppy/osu/releases/download/2022.1205.0/osu.AppImage
+        sha256: deda93a2c945343d82d5f77c729e8206145c2e24f66a33dc3449888655b86e2c
         dest-filename: osu.AppImage
         x-checker-data:
           type: json

--- a/sh.ppy.osu.yaml
+++ b/sh.ppy.osu.yaml
@@ -48,6 +48,8 @@ modules:
       - mv ./squashfs-root/usr/bin/* /app/bin
         # desktop file
       - install -D -m 644 ./squashfs-root/osu!.desktop /app/share/applications/sh.ppy.osu.desktop
+      - desktop-file-edit --remove-key="SingleMainWindow" --set-key="Version" --set-value="1.4" /app/share/applications/sh.ppy.osu.desktop
+      - desktop-file-edit --set-key="X-SingleMainWindow" --set-value="true" /app/share/applications/sh.ppy.osu.desktop
       - desktop-file-edit --set-key="Icon" --set-value="sh.ppy.osu" /app/share/applications/sh.ppy.osu.desktop
       - desktop-file-edit --set-key="Exec" --set-value="start-osu %F" /app/share/applications/sh.ppy.osu.desktop
       - desktop-file-edit --set-key="StartupWMClass" --set-value="osu!" /app/share/applications/sh.ppy.osu.desktop
@@ -82,8 +84,8 @@ modules:
       - install -D -m 644 sh.ppy.osu.appdata.xml /app/share/metainfo/sh.ppy.osu.appdata.xml
     sources:
       - type: file
-        url: https://github.com/ppy/osu/releases/download/2022.1101.0/osu.AppImage
-        sha256: b70ceda8d96a2489cd6004cb36c2d2bf23f2912317313e9dce9356309c1f9e92
+         url: https://github.com/ppy/osu/releases/download/2022.1205.0/osu.AppImage
+         sha256: deda93a2c945343d82d5f77c729e8206145c2e24f66a33dc3449888655b86e2c
         dest-filename: osu.AppImage
         x-checker-data:
           type: json


### PR DESCRIPTION
Flathub should be able build now. I only fixed it for the latest release. please tell me if I should make it to work for the previous release first.

for some reason `flatpak-builder` checks the desktop entry before all edit commands are applied which is what made me write a one liner that fixes both errors first. I have no clue how to do this differently so please do tell me if there is a different solution for this. 

Time for me to enjoy some lazer updates back to back.