### PR TITLE
Fix for importing data from osu!stable installed using the osu!winell…

### DIFF
--- a/sh.ppy.osu.yaml
+++ b/sh.ppy.osu.yaml
@@ -23,6 +23,7 @@ finish-args:
   - --filesystem=xdg-run/app/com.discordapp.DiscordCanary:create
   - --filesystem=~/.wine:ro
   - --filesystem=~/.osu:ro
+  - --filesystem=~/.local/share/osu-wine:ro
 command: start-osu
 modules:
   - name: libevdev


### PR DESCRIPTION
…o install script

https://github.com/NelloKudo/osu-winello uses the ~/.local/share/osu-wine data directory by default.