### PR TITLE
Fix AppStream metadata

### DIFF
--- a/sh.ppy.osu.appdata.xml
+++ b/sh.ppy.osu.appdata.xml
@@ -7,17 +7,15 @@
     <summary xml:lang="ru">Популярная ритм-игра с открытым исходным кодом</summary>
     <description>
         <p>Open source rhythm game written in C# and inspired by Osu! Tatakae! Ouendan</p>
+        <p xml:lang="ru">Бесплатная популярная ритм-игра с открытым исходным кодом написанная на C# и вдохнавлённая Osu! Tatakae! Ouendan</p>
         <p>
             Attention: Unofficial package. Please report all bugs found on https://github.com/flathub/sh.ppy.osu (if you think they may be related to a flatpak)
         </p>
-        <p>For official release, please visit https://github.com/ppy/osu/releases</p>
-    </description>
-    <description xml:lang="ru">
-        <p>Бесплатная популярная ритм-игра с открытым исходным кодом написанная на C# и вдохнавлённая Osu! Tatakae! Ouendan</p>
-        <p>
+        <p xml:lang="ru">
             Внимание: неофициальный пакет. Пожалуйста, сообщайте о всех найденых багах на https://github.com/flathub/sh.ppy.osu (если вы думаете, что они могут быть связаны с flatpak)
         </p>
-        <p>Официальную сборку можно скачать с https://github.com/ppy/osu/releases</p>
+        <p>For official release, please visit https://github.com/ppy/osu/releases</p>
+        <p xml:lang="ru">Официальную сборку можно скачать с https://github.com/ppy/osu/releases</p>
     </description>
     <url type="homepage">https://osu.ppy.sh</url>
     <categories>

--- a/sh.ppy.osu.appdata.xml
+++ b/sh.ppy.osu.appdata.xml
@@ -7,15 +7,7 @@
     <summary xml:lang="ru">Популярная ритм-игра с открытым исходным кодом</summary>
     <description>
         <p>Open source rhythm game written in C# and inspired by Osu! Tatakae! Ouendan</p>
-        <p xml:lang="ru">Бесплатная популярная ритм-игра с открытым исходным кодом написанная на C# и вдохнавлённая Osu! Tatakae! Ouendan</p>
-        <p>
-            Attention: Unofficial package. Please report all bugs found on https://github.com/flathub/sh.ppy.osu (if you think they may be related to a flatpak)
-        </p>
-        <p xml:lang="ru">
-            Внимание: неофициальный пакет. Пожалуйста, сообщайте о всех найденых багах на https://github.com/flathub/sh.ppy.osu (если вы думаете, что они могут быть связаны с flatpak)
-        </p>
-        <p>For official release, please visit https://github.com/ppy/osu/releases</p>
-        <p xml:lang="ru">Официальную сборку можно скачать с https://github.com/ppy/osu/releases</p>
+        <p>Attention: Unofficial package. For official release, please visit <url type="homepage">https://github.com/ppy/osu/releases</url>.</p>
     </description>
     <url type="homepage">https://osu.ppy.sh</url>
     <categories>

--- a/sh.ppy.osu.appdata.xml
+++ b/sh.ppy.osu.appdata.xml
@@ -6,7 +6,7 @@
     <summary>Rhythm is just a *click* away!</summary>
     <description>
         <p>Open source rhythm game written in C# and inspired by Osu! Tatakae! Ouendan</p>
-        <p><em>Attention: Unofficial package.</em> For official release, please visit the homepage.</p>
+        <p><em>Attention: Unofficial package.</em> For official releases, please visit the osu! website.</p>
     </description>
     <url type="homepage">https://osu.ppy.sh</url>
     <categories>

--- a/sh.ppy.osu.appdata.xml
+++ b/sh.ppy.osu.appdata.xml
@@ -6,7 +6,7 @@
     <summary>Rhythm is just a *click* away!</summary>
     <description>
         <p>Open source rhythm game written in C# and inspired by Osu! Tatakae! Ouendan</p>
-        <p>Attention: Unofficial package. For official release, please visit <url>https://github.com/ppy/osu/releases</url>.</p>
+        <p><em>Attention: Unofficial package.</em> For official release, please visit the homepage.</p>
     </description>
     <url type="homepage">https://osu.ppy.sh</url>
     <categories>

--- a/sh.ppy.osu.appdata.xml
+++ b/sh.ppy.osu.appdata.xml
@@ -3,11 +3,10 @@
     <id>sh.ppy.osu</id>
     <name>osu!</name>
     <metadata_license>CC0-1.0</metadata_license>
-    <summary>A free-to-win rhythm game. Rhythm is just a *click* away!</summary>
-    <summary xml:lang="ru">Популярная ритм-игра с открытым исходным кодом</summary>
+    <summary>Rhythm is just a *click* away!</summary>
     <description>
         <p>Open source rhythm game written in C# and inspired by Osu! Tatakae! Ouendan</p>
-        <p>Attention: Unofficial package. For official release, please visit <url type="homepage">https://github.com/ppy/osu/releases</url>.</p>
+        <p>Attention: Unofficial package. For official release, please visit <url>https://github.com/ppy/osu/releases</url>.</p>
     </description>
     <url type="homepage">https://osu.ppy.sh</url>
     <categories>


### PR DESCRIPTION
This should resolve failed builds in https://github.com/flathub/sh.ppy.osu/pull/155

The build failed with error [`metainfo-localized-description-tag`](https://www.freedesktop.org/software/appstream/docs/chap-Validation.html#asv-metainfo-localized-description-tag). The description localisation should be translated by each paragraphs in the `description` tag, not as a whole in another `description` tag.