### PR TITLE
fix vulkan renderer initialization by symlinking libdl to /app/bin

### DIFF
--- a/sh.ppy.osu.yaml
+++ b/sh.ppy.osu.yaml
@@ -88,6 +88,7 @@ modules:
       - rm -r /app/share/icons/breeze/*/apps
         # See https://github.com/flathub/flathub/pull/2619#issuecomment-971378698
       - ln -s /usr/lib/x86_64-linux-gnu/libasound.so.2 /app/bin/libasound.so
+      - ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /app/bin/libdl.so
       - install -D -m 644 x-osu.xml /app/share/mime/packages/${FLATPAK_ID}.xml
       - install -D -m 644 sh.ppy.osu.appdata.xml /app/share/metainfo/sh.ppy.osu.appdata.xml
     sources:


### PR DESCRIPTION
when the "vulkan (experimental)" renderer is selected, it tries looking for libdl.so in `/app/bin/` but it only exists in `/usr/lib/x86_64-linux-gnu/`. adding a symlink fixes this issue
![image](https://github.com/flathub/sh.ppy.osu/assets/26211918/cb9edd60-9f15-4a21-9d38-e8adb80636cf)