### PR TITLE
Add permissions to access /tmp/lazer

### DIFF
--- a/sh.ppy.osu.yaml
+++ b/sh.ppy.osu.yaml
@@ -24,6 +24,7 @@ finish-args:
   - --filesystem=~/.wine:ro
   - --filesystem=~/.osu:ro
   - --filesystem=~/.local/share/osu-wine:ro
+  - --filesystem=/tmp/lazer:rw
 command: start-osu
 modules:
   - name: libevdev


### PR DESCRIPTION
Fixes an issue with users not being able to open the directory for maps which have been mounted externally. Access is given specifically to `/tmp/lazer` in order to not break program isolation.

This PR requires a change on the osu! side for beatmaps to be mounted at `/tmp/lazer` instead of the current `/tmp` location.